### PR TITLE
2025/09/07 fix : 챌린지 클리어시간 차감오류 수정 및 관리자페이지 챌린지 조회필터 수정

### DIFF
--- a/src/main/java/com/godLife/project/controller/AdminController/ChallAdminController.java
+++ b/src/main/java/com/godLife/project/controller/AdminController/ChallAdminController.java
@@ -163,87 +163,21 @@ public class ChallAdminController {
 
   //  -------------- 챌린지 검색 API (제목, 카테고리) -------------
   @GetMapping("/search")
-  public List<ChallengeDTO> searchChallenges(
+  public ResponseEntity<Map<String, Object>> searchChallenges(
           @RequestParam(required = false) String challTitle,
           @RequestParam(required = false) String challCategory,
-          @RequestParam(defaultValue = "0") int page,
+          @RequestParam(required = false) String challState, // 상태 필터 추가
+          @RequestParam(defaultValue = "1") int page,
           @RequestParam(defaultValue = "10") int size,
-          @RequestParam(defaultValue = "chall_idx DESC") String sort
+          @RequestParam(defaultValue = "challCreatedAt") String sort
   ) {
-    int offset = page * size;
-    return challAdminService.searchChallenges(challTitle, challCategory, offset, size, sort);
-  }
-
-
-  // ------------- 리스트 조회 -----------------
-  @GetMapping("/latest")
-  public ResponseEntity<Map<String, Object>> getAllChallengesAdmin(
-          @RequestParam(required = false) String challState, // 상태 필터 (선택)
-          @RequestParam(defaultValue = "1") int page,
-          @RequestParam(defaultValue = "10") int size) {
-
-    int offset = (page - 1) * size;
-
-    // 상태에 맞는 챌린지 조회
-    List<ChallengeDTO> challenges = challAdminService.getAllChallengesAdmin(challState, offset, size);
-
-    // 상태 조건에 맞는 전체 개수 조회
-    int totalChallenges = challAdminService.getTotalLatestChallenges(challState);
-    int totalPages = (int) Math.ceil((double) totalChallenges / size);
-
-    if (challenges.isEmpty()) {
-      return ResponseEntity.status(HttpStatus.NO_CONTENT)
-              .body(createResponse(204, "챌린지가 없습니다."));
-    }
-
-    Map<String, Object> response = createResponse(200, "챌린지 조회 성공");
-    response.put("challenges", challenges);
-    response.put("totalPages", totalPages);
-    response.put("currentPage", page);
-    response.put("pageSize", size);
-    response.put("challState", challState == null ? "전체" : challState);
+    Map<String, Object> response = challAdminService.searchChallenges(
+            challTitle, challCategory, challState, page, size, sort
+    );
 
     return ResponseEntity.ok(response);
   }
 
-  // ------------- 카테고리 조회 -----------------
-  @GetMapping("/latest/{challCategoryIdx}")
-  public ResponseEntity<Map<String, Object>> getChallengesByCategoryId(
-          @PathVariable int challCategoryIdx,
-          @RequestParam(defaultValue = "1") int page,
-          @RequestParam(defaultValue = "10") int size) {
-
-    List<ChallengeDTO> challenges = challAdminService.getChallengesByCategoryId(challCategoryIdx, page, size);
-    int totalChallenges = challAdminService.getTotalChallengesByCategory(challCategoryIdx);
-    int totalPages = (int) Math.ceil((double) totalChallenges / size);
-
-    Map<String, Object> response;
-
-    if (challenges.isEmpty()) {
-      response = createResponse(200, "해당 카테고리에 챌린지가 없습니다.");
-      response.put("challenges", new ArrayList<>()); // 빈 리스트
-      response.put("totalPages", 0);
-      response.put("currentPage", page);
-      response.put("pageSize", size);
-      return ResponseEntity.ok(response);
-    }
-
-    response = createResponse(200, "카테고리별 챌린지 조회 성공");
-    response.put("challenges", challenges);
-    response.put("totalPages", totalPages);
-    response.put("currentPage", page);
-    response.put("pageSize", size);
-
-    return ResponseEntity.ok(response);
-  }
-
-  // 응답 생성 메서드
-  private Map<String, Object> createResponse(int status, String message) {
-    Map<String, Object> response = new HashMap<>();
-    response.put("status", status);
-    response.put("message", message);
-    return response;
-  }
 
   // -------------  챌린지 상세 조회  -----------------
   @GetMapping("/detail/{challIdx}")

--- a/src/main/java/com/godLife/project/enums/ChallengeState.java
+++ b/src/main/java/com/godLife/project/enums/ChallengeState.java
@@ -5,7 +5,7 @@ import java.util.Arrays;
 public enum ChallengeState {
     PUBLISHED("PUBLISHED", "게시중"),
     IN_PROGRESS("IN_PROGRESS", "진행중"),
-    COMPLETED("COMPLETED", "완료됨"),
+    FINISHED("FINISHED", "완료됨"),
     END("END", "종료");
 
     private final String code;   // DB 및 내부 처리용

--- a/src/main/java/com/godLife/project/mapper/AdminMapper/ChallAdminMapper.java
+++ b/src/main/java/com/godLife/project/mapper/AdminMapper/ChallAdminMapper.java
@@ -26,30 +26,23 @@ public interface ChallAdminMapper {
   int earlyFinishChallenge(Long challIdx);
   // 유저 참여형 챌린지 최초 참여시 시작/종료시간, 상태 업데이트
   void updateChallengeStartTime(Map<String, Object> params);
+
   // 챌린지 검색 (제목, 카테고리)
   List<ChallengeDTO> searchChallenges(
           @Param("challTitle") String challTitle,
           @Param("challCategory") String challCategory,
+          @Param("challState") String challState,
           @Param("offset") int offset,
           @Param("size") int size,
           @Param("sort") String sort
   );
-  // 진행 중인 챌린지를 종료 상태로 자동 변경
-  int updateChallengesToEndStatus(@Param("now") LocalDateTime now);
+  // 총 게시글 수 조회 (페이징 계산용)
+  int countSearchChallenges(
+          @Param("challTitle") String challTitle,
+          @Param("challCategory") String challCategory,
+          @Param("challState") String challState
+  );
 
-  // 최신 챌린지 조회 (페이징 적용)
-  List<ChallengeDTO> getAllChallengesAdmin(String challState, @Param("offset") int offset, @Param("size") int size);
-
-  // 최신 챌린지 총 개수 조회
-  int getTotalLatestChallenges(@Param("challState") String challState);
-
-  // 카테고리별 챌린지 조회 (페이징 적용)
-  List<ChallengeDTO> getChallengesByCategoryId(@Param("challCategoryIdx") int challCategoryIdx,
-                                               @Param("offset") int offset,
-                                               @Param("size") int size);
-
-  // 카테고리별 챌린지 총 개수 조회
-  int countChallengesByCategoryId(@Param("challCategoryIdx") int challCategoryIdx);
 
   // 챌린지 상세조회
   ChallengeDTO challengeDetail(Long challIdx);

--- a/src/main/java/com/godLife/project/service/impl/ChallengeServiceImpl.java
+++ b/src/main/java/com/godLife/project/service/impl/ChallengeServiceImpl.java
@@ -71,7 +71,7 @@ public class ChallengeServiceImpl implements ChallengeService {
         if (challenge.getChallEndTime() != null
                 && LocalDateTime.now().isAfter(challenge.getChallEndTime())
                 && !challenge.getChallState().equals(ChallengeState.END.getCode())
-                && !challenge.getChallState().equals(ChallengeState.COMPLETED.getCode())) {
+                && !challenge.getChallState().equals(ChallengeState.FINISHED.getCode())) {
             challenge.setChallState(ChallengeState.END.getCode());
         }
 

--- a/src/main/java/com/godLife/project/service/impl/adminImpl/ChallAdminServiceImpl.java
+++ b/src/main/java/com/godLife/project/service/impl/adminImpl/ChallAdminServiceImpl.java
@@ -102,37 +102,34 @@ public class ChallAdminServiceImpl implements ChallAdminService {
   }
 
 
-  // 챌린지 검색
-  public List<ChallengeDTO> searchChallenges(String challTitle, String challCategory, int offset, int size, String sort) {
-    return challAdminMapper.searchChallenges(challTitle, challCategory, offset, size, sort);
-  }
-
-
 
   // --------------------- 조회 -----------------------
-  // ----------------- 최신 챌린지 조회 (페이징 적용) -----------------
-  @Override
-  public List<ChallengeDTO> getAllChallengesAdmin(String challState, int offset, int size) {
-    return challAdminMapper.getAllChallengesAdmin(challState, offset, size);
-  }
 
-  // 최신 챌린지 총 개수 조회
+  // 챌린지 검색
   @Override
-  public int getTotalLatestChallenges(String challState) {
-    return challAdminMapper.getTotalLatestChallenges(challState);
-  }
+  public Map<String, Object> searchChallenges(String challTitle, String challCategory, String challState,
+                                              int page, int size, String sort) {
+    int offset = (page - 1) * size; //
 
+    List<ChallengeDTO> challenges = challAdminMapper.searchChallenges(
+            challTitle, challCategory, challState, offset, size, sort
+    );
 
-  // -----------------카테고리별 챌린지 조회 (페이징 적용) -----------------
-  @Override
-  public List<ChallengeDTO> getChallengesByCategoryId(int categoryIdx, int page, int size) {
-    int offset = (page - 1) * size;
-    return challAdminMapper.getChallengesByCategoryId(categoryIdx, offset, size);
-  }
-  // 카테고리별 챌린지 총 개수 조회
-  @Override
-  public int getTotalChallengesByCategory(int categoryIdx) {
-    return challAdminMapper.countChallengesByCategoryId(categoryIdx);
+    int totalChallenges = challAdminMapper.countSearchChallenges(
+            challTitle, challCategory, challState
+    );
+
+    int totalPages = (int) Math.ceil((double) totalChallenges / size);
+
+    Map<String, Object> response = new HashMap<>();
+    response.put("challenges", challenges);
+    response.put("totalPages", totalPages);
+    response.put("currentPage", page);
+    response.put("pageSize", size);
+    response.put("totalChallenges", totalChallenges);
+    response.put("challState", challState == null ? "전체" : challState);
+
+    return response;
   }
 
 

--- a/src/main/java/com/godLife/project/service/interfaces/AdminInterface/ChallAdminService.java
+++ b/src/main/java/com/godLife/project/service/interfaces/AdminInterface/ChallAdminService.java
@@ -5,6 +5,7 @@ import org.apache.ibatis.annotations.Param;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
+import java.util.Map;
 
 @Service
 public interface ChallAdminService {
@@ -19,21 +20,17 @@ public interface ChallAdminService {
   // 조기 종료
   void earlyFinishChallenge(Long challIdx);
 
-  // 챌린지 검색 (제목, 카테고리)
-  List<ChallengeDTO> searchChallenges(String challTitle,
-                                      String challCategory,
-                                      int offset, int size, String sort);
 
     // --------------------- 조회 -----------------------
-    // ----------------- 최신 챌린지 조회 (페이징 적용) -----------------
-    List<ChallengeDTO> getAllChallengesAdmin(String challState, int offset, int size);
-
-    int getTotalLatestChallenges(String challState);         // 최신 챌린지 총 개수 조회
-
-
-  List<ChallengeDTO> getChallengesByCategoryId(int categoryIdx, int page, int size);   // 카테고리별 챌린지 조회 (페이징 적용)
-
-  int getTotalChallengesByCategory(int categoryIdx);        // 카테고리별 챌린지 총 개수 조회
+    // 챌린지 검색 및 조회(페이징 적용)
+    Map<String, Object> searchChallenges(
+            @Param("challTitle") String challTitle,
+            @Param("challCategory") String challCategory,
+            @Param("challState") String challState,   // 상태 필터 추가
+            @Param("offset") int offset,
+            @Param("size") int size,
+            @Param("sort") String sort
+    );
 
   ChallengeDTO getChallengeDetail(Long challIdx);          // 챌린지 상세 조회
 

--- a/src/main/resources/mybatis/mapper/AdminMapper/ChallAdminMapper.xml
+++ b/src/main/resources/mybatis/mapper/AdminMapper/ChallAdminMapper.xml
@@ -72,13 +72,13 @@
 
 
     <!-- 관리자: 챌린지 검색 + 상태별 조회 -->
-    <select id="getAllChallengesAdmin" resultType="com.godLife.project.dto.contents.ChallengeDTO">
+    <select id="searchChallenges" resultType="com.godLife.project.dto.contents.ChallengeDTO">
         SELECT
         CT.CHALL_IDX,
         CT.CHALL_TITLE,
         CT.CHALL_DESCRIPTION,
         CT.CHALL_CATEGORY_IDX,
-        CAT.CATEGORY_NAME,
+        CAT.CHALL_NAME,
         CT.MAX_PARTICIPANTS,
         CT.CHALL_END_TIME,
         COUNT(CJ.USER_IDX) AS CURRENT_PARTICIPANTS,
@@ -93,7 +93,7 @@
                 LOWER(CT.CHALL_TITLE) LIKE CONCAT('%', LOWER(#{challTitle}), '%')
             </if>
             <if test="challCategory != null and challCategory != ''">
-                AND LOWER(CAT.CATEGORY_NAME) LIKE CONCAT('%', LOWER(#{challCategory}), '%')
+                AND LOWER(CAT.CHALL_NAME) LIKE CONCAT('%', LOWER(#{challCategory}), '%')
             </if>
             <if test="challState != null and challState != ''">
                 AND CT.CHALL_STATE = #{challState}
@@ -104,7 +104,7 @@
         CT.CHALL_TITLE,
         CT.CHALL_DESCRIPTION,
         CT.CHALL_CATEGORY_IDX,
-        CAT.CATEGORY_NAME,
+        CAT.CHALL_NAME,
         CT.MAX_PARTICIPANTS,
         CT.CHALL_END_TIME,
         CT.CHALL_CREATED_AT,
@@ -123,36 +123,34 @@
         LIMIT #{size} OFFSET #{offset}
     </select>
 
+    <!-- 관리자: 챌린지 검색 + 상태별 조회 총 게시글 수 -->
+    <select id="countSearchChallenges" resultType="int">
+        SELECT COUNT(*)
+        FROM CHALL_TABLE CT
+        JOIN CHALL_CATEGORY CAT ON CT.CHALL_CATEGORY_IDX = CAT.CHALL_CATEGORY_IDX
+        <where>
+            <!-- 제목 검색 -->
+            <if test="challTitle != null and challTitle != ''">
+                AND LOWER(CT.CHALL_TITLE) LIKE CONCAT('%', LOWER(#{challTitle}), '%')
+            </if>
+
+            <!-- 카테고리 검색 -->
+            <if test="challCategory != null and challCategory != ''">
+                AND LOWER(CAT.CHALL_NAME) LIKE CONCAT('%', LOWER(#{challCategory}), '%')
+            </if>
+
+            <!-- 상태 검색 -->
+            <if test="challState != null and challState != ''">
+                AND CT.CHALL_STATE = #{challState}
+            </if>
+        </where>
+    </select>
+
     <!-- 챌린지 존재 확인 -->
     <select id="existsById" resultType="int">
         SELECT COUNT(*) FROM CHALL_TABLE WHERE CHALL_IDX = #{challIdx}
     </select>
 
-
-    <!-- 카테고리별 챌린지 조회 (페이징 적용) -->
-    <select id="getChallengesByCategoryId" resultType="com.godLife.project.dto.request.ChallRequestDTO">
-        SELECT
-        CT.CHALL_IDX,
-        CT.CHALL_TITLE,
-        CT.CHALL_DESCRIPTION,
-        CT.CHALL_CATEGORY_IDX,
-        CT.MAX_PARTICIPANTS,
-        CT.CHALL_END_TIME,
-        CT.CHALL_CREATED_AT
-        FROM CHALL_TABLE CT
-        WHERE CT.CHALL_CATEGORY_IDX = #{challCategoryIdx}
-        AND (CT.CHALL_END_TIME IS NULL OR CT.CHALL_END_TIME > NOW())
-        ORDER BY CT.CHALL_CREATED_AT DESC
-        LIMIT #{size} OFFSET #{offset}
-    </select>
-
-    <!-- 카테고리별 챌린지 총 개수 조회 -->
-    <select id="countChallengesByCategoryId" resultType="int">
-        SELECT COUNT(*)
-        FROM CHALL_TABLE
-        WHERE CHALL_CATEGORY_IDX = #{challCategoryIdx}
-        AND (CHALL_END_TIME IS NULL OR CHALL_END_TIME > NOW())
-    </select>
 
 
     <!-- 챌린지 상세정보 조회 -->

--- a/src/main/resources/mybatis/mapper/ChallengeMapper.xml
+++ b/src/main/resources/mybatis/mapper/ChallengeMapper.xml
@@ -186,20 +186,13 @@
         AND VERIFY_DATE = #{today}
     </select>
 
-
-    <!-- 남은 클리어 시간 차감 및 상태 변경 -->
+    <!-- 인증시 클리어시간 차감 -->
     <update id="updateClearTime">
         UPDATE CHALL_TABLE
-        SET TOTAL_CLEAR_TIME = CASE
-                                   WHEN TOTAL_CLEAR_TIME - #{elapsedTime} <![CDATA[<]]> 0 THEN 0
-                                   ELSE TOTAL_CLEAR_TIME - #{elapsedTime}
-            END,
-            CHALL_STATE = CASE
-                              WHEN TOTAL_CLEAR_TIME - #{elapsedTime} <![CDATA[<=]]> 0 THEN 'FINISHED'
-                              ELSE CHALL_STATE
-                END
+        SET TOTAL_CLEAR_TIME = GREATEST(TOTAL_CLEAR_TIME - #{elapsedTime}, 0)
         WHERE CHALL_IDX = #{challIdx}
     </update>
+
 
     <!-- 인증을 통해 감소한 총 시간 조회 -->
     <select id="getElapsedClearTime" resultType="int">


### PR DESCRIPTION
- 관리자 페이지 조회는 검색 (/api/search) 를 사용하고, 사용하지 않는 조회 api 삭제.
- 챌린지 인증시 총 클리어시간이 0에 도달하지 않아도 챌린지 상태가 FINISHED (종료됨) 값으로 변경되는 오류 수정.